### PR TITLE
[FEATURE] Add expires for queue on assertQueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config.json
 .idea
 coverage
 .vscode
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config.json
 coverage
 .vscode
 yarn.lock
+package-lock.json

--- a/lib/service_pub_queue_rabbit.js
+++ b/lib/service_pub_queue_rabbit.js
@@ -20,6 +20,7 @@ class ServicePubQueueRabbit extends Component.mixin(AsyncEmitter) {
         this._status = "ok";
         this._initializing = false;
         this._connection = null;
+        this._withExpire = true;
         this._channels = {};
         this._registry = {};
         this._namespace = config.default("service.rabbit.namespace", "default");
@@ -73,10 +74,28 @@ class ServicePubQueueRabbit extends Component.mixin(AsyncEmitter) {
 
         this._channels[service][event] = channel;
 
-        yield channel.assertQueue(queueName, {
+        const queueOpts = {
             durable: true,
-            expires: this.expireTime,
-        });
+        };
+
+        if (this._withExpire) {
+            Object.assign(queueOpts, { expires: this.expireTime });
+        }
+
+        // by default, assert queue with `expires` header. if queue is exists and
+        // don't have `expires` header, rabbitMQ will throw an error and close channel.
+        // we catch the error on `close` or `error` emit (amqp.node lib emit those error)
+        // and re-init this class
+        try {
+            yield channel.assertQueue(queueName, queueOpts);
+        } catch (e) {
+            this._initializing = false;
+
+            // dont use `expires` header on re-init
+            this._withExpire = false;
+            this._connection.on("close", this.init.bind(this));
+            this._connection.on("error", this.init.bind(this));
+        }
     }
 
     info() {

--- a/lib/service_pub_queue_rabbit.js
+++ b/lib/service_pub_queue_rabbit.js
@@ -23,6 +23,7 @@ class ServicePubQueueRabbit extends Component.mixin(AsyncEmitter) {
         this._channels = {};
         this._registry = {};
         this._namespace = config.default("service.rabbit.namespace", "default");
+        this.expireTime = this.config.default("service.rabbit.expireTime", 1000 * 60 * 30); // 30 mins
 
         this.servicePubQueue.on("triggerQueue", this.publishEvent.bind(this));
         this.amqp.on("connected", () => {
@@ -72,7 +73,10 @@ class ServicePubQueueRabbit extends Component.mixin(AsyncEmitter) {
 
         this._channels[service][event] = channel;
 
-        yield channel.assertQueue(queueName, { durable: true });
+        yield channel.assertQueue(queueName, {
+            durable: true,
+            expires: this.expireTime,
+        });
     }
 
     info() {

--- a/lib/service_sub_queue_rabbit.js
+++ b/lib/service_sub_queue_rabbit.js
@@ -20,6 +20,7 @@ class ServiceSubRabbit extends ServiceSubQueue {
         this._status = "ok";
         this._initializing = false;
         this._connection = null;
+        this._withExpire = true;
         this._namespace = config.default("service.rabbit.namespace", "default");
         this.expireTime = this.config.default("service.rabbit.expireTime", 1000 * 60 * 30); // 30 mins
 
@@ -62,10 +63,30 @@ class ServiceSubRabbit extends ServiceSubQueue {
         if (channel) {
             let queueName = `${this._namespace}.queue.${this.SERVICE_NAME}.${event}`;
 
-            yield channel.assertQueue(queueName, {
+            const queueOpts = {
                 durable: true,
-                expires: this.expireTime,
-            });
+            };
+
+            if (this._withExpire) {
+                Object.assign(queueOpts, { expires: this.expireTime });
+            }
+
+            // by default, assert queue with `expires` header. if queue is exists and
+            // don't have `expires` header, rabbitMQ will throw an error and close channel.
+            // we catch the error on `close` or `error` emit (amqp.node lib emit those error)
+            // and re-init this class
+            try {
+                yield channel.assertQueue(queueName, queueOpts);
+            } catch (e) {
+                this.logger.error("Error service_sub_queue_rabbit createQueue", e);
+
+                this._initializing = false;
+
+                // dont use `expires` header on re-init
+                this._withExpire = false;
+                this._connection.on("close", this.init.bind(this));
+                this._connection.on("error", this.init.bind(this));
+            }
 
             channel.consume(queueName, async(function* (message) {
                 try {

--- a/lib/service_sub_queue_rabbit.js
+++ b/lib/service_sub_queue_rabbit.js
@@ -21,6 +21,7 @@ class ServiceSubRabbit extends ServiceSubQueue {
         this._initializing = false;
         this._connection = null;
         this._namespace = config.default("service.rabbit.namespace", "default");
+        this.expireTime = this.config.default("service.rabbit.expireTime", 1000 * 60 * 30); // 30 mins
 
         this.amqp.on("connected", () => {
             this.init();
@@ -61,7 +62,10 @@ class ServiceSubRabbit extends ServiceSubQueue {
         if (channel) {
             let queueName = `${this._namespace}.queue.${this.SERVICE_NAME}.${event}`;
 
-            yield channel.assertQueue(queueName, { durable: true });
+            yield channel.assertQueue(queueName, {
+                durable: true,
+                expires: this.expireTime,
+            });
 
             channel.consume(queueName, async(function* (message) {
                 try {

--- a/lib/service_sub_rabbit.js
+++ b/lib/service_sub_rabbit.js
@@ -98,9 +98,7 @@ class ServiceSubRabbit extends ServiceSub {
 
         yield channel.assertQueue(queueName, {
             durable: true,
-            arguments: {
-                expires: this.expireTime,
-            }
+            expires: this.expireTime,
         });
 
         channel.consume(queueName, async(function* (message) {

--- a/lib/service_sub_rabbit.js
+++ b/lib/service_sub_rabbit.js
@@ -24,6 +24,7 @@ class ServiceSubRabbit extends ServiceSub {
         this.expireTime = this.config.default("service.rabbit.expireTime", 1000 * 60 * 30); // 30 mins
         this.remainingAttempts = this.maxAttempts - 1;
 
+        this._withExpire = true;
         this._status = "ok";
         this._initializing = false;
         this._connection = null;
@@ -36,8 +37,9 @@ class ServiceSubRabbit extends ServiceSub {
     }
 
     *initialize() {
-        if (this.amqp.getConnection())
+        if (this.amqp.getConnection()) {
             this.init();
+        }
     }
 
     *init() {
@@ -96,10 +98,28 @@ class ServiceSubRabbit extends ServiceSub {
         let channel = this._channels[event];
         let queueName = `${this._namespace}.${this.SERVICE_NAME}.${event}`;
 
-        yield channel.assertQueue(queueName, {
+        const queueOpts = {
             durable: true,
-            expires: this.expireTime,
-        });
+        };
+
+        if (this._withExpire) {
+            Object.assign(queueOpts, { expires: this.expireTime });
+        }
+
+        // by default, assert queue with `expires` header. if queue is exists and
+        // don't have `expires` header, rabbitMQ will throw an error and close channel.
+        // we catch the error on `close` or `error` emit (amqp.node lib emit those error)
+        // and re-init this class
+        try {
+            yield channel.assertQueue(queueName, queueOpts);
+        } catch (e) {
+            this._initializing = false;
+
+            // dont use `expires` header on re-init
+            this._withExpire = false;
+            this._connection.on("close", this.init.bind(this));
+            this._connection.on("error", this.init.bind(this));
+        }
 
         channel.consume(queueName, async(function* (message) {
             try {
@@ -124,10 +144,29 @@ class ServiceSubRabbit extends ServiceSub {
             let queueName = this._namespace + "." + publisherName + "." + this.SERVICE_NAME + "." + event;
             let exchangeName = this._namespace + "." + publisherName + "." + event;
 
-            yield channel.assertQueue(queueName, {
+            const queueOpts = {
                 durable: true,
-                expires: this.expireTime,
-            });
+            };
+
+            if (this._withExpire) {
+                Object.assign(queueOpts, { expires: this.expireTime });
+            }
+
+            // by default, assert queue with `expires` header. if queue is exists and
+            // don't have `expires` header, rabbitMQ will throw an error and close channel.
+            // we catch the error on `close` or `error` emit (amqp.node lib emit those error)
+            // and re-init this class
+            try {
+                yield channel.assertQueue(queueName, queueOpts);
+            } catch (e) {
+                this._initializing = false;
+
+                // dont use `expires` header on re-init
+                this._withExpire = false;
+                this._connection.on("close", this.init.bind(this));
+                this._connection.on("error", this.init.bind(this));
+            }
+
             yield channel.assertExchange(exchangeName, "fanout", { durable: true });
             yield channel.bindQueue(queueName, exchangeName, "");
             this._queues.push(queueName);

--- a/lib/service_sub_rabbit.js
+++ b/lib/service_sub_rabbit.js
@@ -21,6 +21,7 @@ class ServiceSubRabbit extends ServiceSub {
 
         this.maxAttempts = this.config.default("service.rabbit.maxAttempts", 5);
         this.retryDelay = this.config.default("service.rabbit.retryDelay", 5000);
+        this.expireTime = this.config.default("service.rabbit.expireTime", 1000 * 60 * 30); // 30 mins
         this.remainingAttempts = this.maxAttempts - 1;
 
         this._status = "ok";
@@ -95,7 +96,12 @@ class ServiceSubRabbit extends ServiceSub {
         let channel = this._channels[event];
         let queueName = `${this._namespace}.${this.SERVICE_NAME}.${event}`;
 
-        yield channel.assertQueue(queueName, { durable: true });
+        yield channel.assertQueue(queueName, {
+            durable: true,
+            arguments: {
+                expires: this.expireTime,
+            }
+        });
 
         channel.consume(queueName, async(function* (message) {
             try {
@@ -120,7 +126,10 @@ class ServiceSubRabbit extends ServiceSub {
             let queueName = this._namespace + "." + publisherName + "." + this.SERVICE_NAME + "." + event;
             let exchangeName = this._namespace + "." + publisherName + "." + event;
 
-            yield channel.assertQueue(queueName, { durable: true });
+            yield channel.assertQueue(queueName, {
+                durable: true,
+                expires: this.expireTime,
+            });
             yield channel.assertExchange(exchangeName, "fanout", { durable: true });
             yield channel.bindQueue(queueName, exchangeName, "");
             this._queues.push(queueName);
@@ -169,12 +178,12 @@ class ServiceSubRabbit extends ServiceSub {
                 retryDelay: this.retryDelay,
                 retryStrategy: this.retryStrategy.bind(this),
                 fullResponse: false
-            }
+            };
 
             if (this._secret != null) {
                 jsonBody["headers"] = {
                     "Authorization": `Bearer ${this._secret}`
-                }
+                };
             }
 
             response = yield request(jsonBody);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "then-sleep": "^1.0.1"
     },
     "devDependencies": {
-        "chai": "^3.5.0",
+        "chai": "^4.1.2",
+        "chai-as-promised": "^7.1.1",
         "istanbul": "^0.4.5",
         "mocha": "^2.5.3",
         "supertest": "^2.0.0"

--- a/test/service_sub_queue_rabbit_test.js
+++ b/test/service_sub_queue_rabbit_test.js
@@ -81,7 +81,7 @@ describe("Merapi Plugin Service: Queue Subscriber", function () {
         });
         yield publisherContainer.start();
 
-        subscriberConfig.service.port = 5210 + currentIteration;
+        subscriberConfig.service.port = 5210;
         subscriberAContainer = merapi({
             basepath: __dirname,
             config: subscriberConfig
@@ -94,7 +94,7 @@ describe("Merapi Plugin Service: Queue Subscriber", function () {
         });
         yield subscriberAContainer.start();
 
-        subscriberConfig.service.port = 5310 + currentIteration;
+        subscriberConfig.service.port = 5310;
         subscriberBContainer = merapi({
             basepath: __dirname,
             config: subscriberConfig
@@ -115,11 +115,14 @@ describe("Merapi Plugin Service: Queue Subscriber", function () {
         yield sleep(100);
     }));
 
-    afterEach(function () {
-        subscriberAContainer.stop();
-        subscriberBContainer.stop();
+    afterEach(async(function* () {
+        yield subscriberAContainer.stop();
+        yield subscriberBContainer.stop();
+        yield channel.close();
+        yield connection.close();
+
         currentIteration++;
-    });
+    }));
 
     describe("Subscriber service", function () {
         describe("getServiceInfo", function () {

--- a/test/service_sub_rabbit_test.js
+++ b/test/service_sub_rabbit_test.js
@@ -86,7 +86,7 @@ describe("Merapi Plugin Service: Subscriber", function () {
         });
         yield publisherContainer.start();
 
-        subscriberConfig.service.port = 5010 + currentIteration;
+        subscriberConfig.service.port = 5010;
         subscriberAContainer = merapi({
             basepath: __dirname,
             config: subscriberConfig
@@ -99,7 +99,7 @@ describe("Merapi Plugin Service: Subscriber", function () {
         });
         yield subscriberAContainer.start();
 
-        subscriberConfig.service.port = 5011 + currentIteration;
+        subscriberConfig.service.port = 5011;
         subscriberBContainer = merapi({
             basepath: __dirname,
             config: subscriberConfig
@@ -121,11 +121,14 @@ describe("Merapi Plugin Service: Subscriber", function () {
         yield sleep(100);
     }));
 
-    afterEach(function () {
-        subscriberAContainer.stop();
-        subscriberBContainer.stop();
+    afterEach(async(function* () {
+        yield subscriberAContainer.stop();
+        yield subscriberBContainer.stop();
+        yield channel.close();
+        yield connection.close();
+
         currentIteration++;
-    });
+    }));
 
     describe("Subscriber service", function () {
         describe("getServiceInfo", function () {

--- a/test/service_sub_rabbit_test.js
+++ b/test/service_sub_rabbit_test.js
@@ -24,9 +24,9 @@ describe("Merapi Plugin Service: Subscriber", function () {
     let messageB = [];
     let currentIteration = 1;
 
-    beforeEach(async(function* () {
+    this.timeout(5000);
 
-        this.timeout(5000);
+    beforeEach(async(function* () {
 
         let publisherConfig = {
             name: "publisher",

--- a/test/service_sub_rabbit_test.js
+++ b/test/service_sub_rabbit_test.js
@@ -5,9 +5,12 @@ const expect = chai.expect;
 const request = require("supertest");
 const sleep = require("then-sleep");
 const amqplib = require("amqplib");
+const chaiAsPromised = require("chai-as-promised");
 
 const merapi = require("merapi");
 const { async, Component } = require("merapi");
+
+chai.use(chaiAsPromised);
 
 /* eslint-env mocha */
 
@@ -19,8 +22,9 @@ describe("Merapi Plugin Service: Subscriber", function () {
     let channel = {};
     let messageA = [];
     let messageB = [];
+    let currentIteration = 1;
 
-    before(async(function* () {
+    beforeEach(async(function* () {
 
         this.timeout(5000);
 
@@ -34,12 +38,13 @@ describe("Merapi Plugin Service: Subscriber", function () {
             service: {
                 "rabbit": {
                     "host": "localhost",
-                    "port": 5672
+                    "port": 5672,
+                    "expireTime": 1000 * 30,
                 },
                 "publish": {
                     "incoming_message_subscriber_test": "triggerIncomingMessageSubscriberTest"
                 },
-                "port": 5021
+                "port": 5030 + currentIteration
             }
         };
 
@@ -56,7 +61,8 @@ describe("Merapi Plugin Service: Subscriber", function () {
                     "port": 5672,
                     "consumerPrefetch": 1,
                     "maxAttemtps": 5,
-                    "retryDelay": 50
+                    "retryDelay": 50,
+                    "expireTime": 1000 * 30,
                 },
                 "subscribe": {
                     "yb-core": {
@@ -64,7 +70,7 @@ describe("Merapi Plugin Service: Subscriber", function () {
                     }
                 },
                 "registry": {
-                    "yb-core": "http://localhost:5021"
+                    "yb-core": `http://localhost:${5030 + currentIteration}`
                 }
             }
         };
@@ -80,7 +86,7 @@ describe("Merapi Plugin Service: Subscriber", function () {
         });
         yield publisherContainer.start();
 
-        subscriberConfig.service.port = 5011;
+        subscriberConfig.service.port = 5010 + currentIteration;
         subscriberAContainer = merapi({
             basepath: __dirname,
             config: subscriberConfig
@@ -93,7 +99,7 @@ describe("Merapi Plugin Service: Subscriber", function () {
         });
         yield subscriberAContainer.start();
 
-        subscriberConfig.service.port = 5012;
+        subscriberConfig.service.port = 5011 + currentIteration;
         subscriberBContainer = merapi({
             basepath: __dirname,
             config: subscriberConfig
@@ -115,9 +121,10 @@ describe("Merapi Plugin Service: Subscriber", function () {
         yield sleep(100);
     }));
 
-    after(function () {
+    afterEach(function () {
         subscriberAContainer.stop();
         subscriberBContainer.stop();
+        currentIteration++;
     });
 
     describe("Subscriber service", function () {
@@ -153,6 +160,7 @@ describe("Merapi Plugin Service: Subscriber", function () {
                 let trigger = yield publisherContainer.resolve("triggerIncomingMessageSubscriberTest");
 
                 for (let i = 0; i < 5; i++) {
+                    yield sleep(100);
                     yield trigger(i);
                 }
 
@@ -161,7 +169,6 @@ describe("Merapi Plugin Service: Subscriber", function () {
                 expect(messageB).to.deep.equal([1, 3]);
             }));
         });
-
     });
 
 });


### PR DESCRIPTION
# Summary

This PR will add `x-expires` header on every `assertQueue`. To maintain backward compatibility (queues that created without any `x-expires` header), I've add a fallback mechanism if the `assertQueue` throws an error (rabbitMQ will throw an error if created queue(s) headers is are not equal with `assertQueue` headers).